### PR TITLE
Scheduler.error() signature declares only 2 arguments

### DIFF
--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -124,7 +124,7 @@ class MesosSchedulerDriver(Process):
         self.sched.frameworkMessage(self, executor_id, slave_id, data)
 
     def onFrameworkErrorMessage(self, message, code=0):
-        self.sched.error(self, code, message)
+        self.sched.error(self, message)
 
     def start(self):
         Process.start(self)


### PR DESCRIPTION
Scheduler.error() signature is http://mesos.apache.org/api/latest/java/org/apache/mesos/Scheduler.html#error%28org.apache.mesos.SchedulerDriver,%20java.lang.String%29

First argument is the scheduler driver and second the message, at least since mesos 0.21.1

without this fix handling a framework error fails with:

```
ERROR:pymesos.process:error while call <function handle at 0x23411b8> (tried 1 times)
Traceback (most recent call last):
  File "pymesos/process.py", line 69, in run_jobs
    func(*args, **kw)
  File "pymesos/process.py", line 139, in handle
    f(*args)
  File "pymesos/scheduler.py", line 127, in onFrameworkErrorMessage
    self.sched.error(self, code, message)
TypeError: error() takes exactly 3 arguments (4 given)
```