### PR TITLE
Exclude ZK log replicas entry for Mesos high-availability mode

### DIFF
--- a/pymesos/detector.py
+++ b/pymesos/detector.py
@@ -21,7 +21,7 @@ class MasterDetector(object):
         self.masterSeq = None
 
     def choose(self, children):
-        if not children:
+        if not children or children == ['log_replicas']:
             self.agent.onNoMasterDetectedMessage()
             return True
         masterSeq = min(children)


### PR DESCRIPTION
For Mesos high-availability mode at ZK `/mesos` path could be an additional entry `log_replicas`, `pymesos` detects it as new master node and tries to connect to `0.0.0.0:5050` url as a result. It could lead to an incorrect set of master nodes, and the framework failure.

Some kind of confirmation is [here](http://wjb-tech.blogspot.ru/2015/03/high-availability-with-apache-mesos-and.html).

The fix adds a simple check for `log_replicas` entry. Check it please and let me know if I missed smth.