### PR TITLE
Upgrade Mesos version up to 0.22.1

### DIFF
--- a/mesos.proto
+++ b/mesos.proto
@@ -115,6 +115,9 @@ message ContainerID {
  * in authentication. This field is used for framework API rate
  * exporting and limiting and should be set even if authentication is
  * not enabled if these features are desired.
+ * The webui_url field allows a framework to advertise its web UI, so
+ * that the Mesos web UI can link to it. It is expected to be a full
+ * URL, for example http://my-scheduler.example.com:8080/.
  */
 message FrameworkInfo {
   required string user = 1;
@@ -125,6 +128,7 @@ message FrameworkInfo {
   optional string role = 6 [default = "*"];
   optional string hostname = 7;
   optional string principal = 8;
+  optional string webui_url = 9;
 }
 
 
@@ -278,6 +282,12 @@ message ExecutorInfo {
   // usage information into a time series database for monitoring.
   optional string source = 10;
   optional bytes data = 4;
+
+  // Service discovery information for the executor. It is not
+  // interpreted or acted upon by Mesos. It is up to a service
+  // discovery system to use this information as needed and to handle
+  // executors without service discovery information.
+  optional DiscoveryInfo discovery = 12;
 }
 
 
@@ -309,10 +319,6 @@ message SlaveInfo {
   repeated Attribute attributes = 5;
   optional SlaveID id = 6;
   optional bool checkpoint = 7 [default = false];
-
-  // Deprecated!
-  optional string webui_hostname = 2;
-  optional int32 webui_port = 4 [default = 8081];
 }
 
 
@@ -388,6 +394,40 @@ message Resource {
   optional Value.Ranges ranges = 4;
   optional Value.Set set = 5;
   optional string role = 6 [default = "*"];
+
+  message DiskInfo {
+    // Describes a persistent disk volume.
+    // A persistent disk volume will not be automatically garbage
+    // collected if the task/executor/slave terminates, but is
+    // re-offered to the framework(s) belonging to the 'role'.
+    // A framework can set the ID (if it is not set yet) to express
+    // the intention to create a new persistent disk volume from a
+    // regular disk resource. To reuse a previously created volume, a
+    // framework can launch a task/executor when it receives an offer
+    // with a persistent volume, i.e., ID is set.
+    // NOTE: Currently, we do not allow a persistent disk volume
+    // without a reservation (i.e., 'role' should not be '*').
+    message Persistence {
+      // A unique ID for the persistent disk volume.
+      // NOTE: The ID needs to be unique per role on each slave.
+      required string id = 1;
+    }
+
+    optional Persistence persistence = 1;
+
+    // Describes how this disk resource will be mounted in the
+    // container. If not set, the disk resource will be used as the
+    // sandbox. Otherwise, it will be mounted according to the
+    // 'container_path' inside 'volume'. The 'host_path' inside
+    // 'volume' is ignored.
+    // NOTE: If 'volume' is set but 'persistence' is not set, the
+    // volume will be automatically garbage collected after
+    // task/executor terminates. Currently, if 'persistence' is set,
+    // 'volume' must be set.
+    optional Volume volume = 2;
+  }
+
+  optional DiskInfo disk = 7;
 }
 
 
@@ -421,7 +461,9 @@ message ResourceStatistics {
   optional uint64 mem_anon_bytes = 11;
   optional uint64 mem_mapped_file_bytes = 12;
 
-  // TODO(bmahler): Add disk usage.
+  // Disk Usage Information for executor working directory.
+  optional uint64 disk_limit_bytes = 26;
+  optional uint64 disk_used_bytes = 27;
 
   // Perf statistics.
   optional PerfStatistics perf = 13;
@@ -435,6 +477,16 @@ message ResourceStatistics {
   optional uint64 net_tx_bytes = 19;
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
+
+  // The kernel keeps track of RTT (round-trip time) for its TCP
+  // sockets. RTT is a way to tell the latency of a container.
+  optional double net_tcp_rtt_microsecs_p50 = 22;
+  optional double net_tcp_rtt_microsecs_p90 = 23;
+  optional double net_tcp_rtt_microsecs_p95 = 24;
+  optional double net_tcp_rtt_microsecs_p99 = 25;
+
+  optional double net_tcp_active_connections = 28;
+  optional double net_tcp_time_wait_connections = 29;
 }
 
 
@@ -565,6 +617,44 @@ message Offer {
   repeated Resource resources = 5;
   repeated Attribute attributes = 7;
   repeated ExecutorID executor_ids = 6;
+
+  // Defines an operation that can be performed against offers.
+  message Operation {
+    enum Type {
+      LAUNCH = 1;
+      RESERVE = 2;
+      UNRESERVE = 3;
+      CREATE = 4;
+      DESTROY = 5;
+    }
+
+    message Launch {
+      repeated TaskInfo task_infos = 1;
+    }
+
+    message Reserve {
+      repeated Resource resources = 1;
+    }
+
+    message Unreserve {
+      repeated Resource resources = 1;
+    }
+
+    message Create {
+      repeated Resource volumes = 1;
+    }
+
+    message Destroy {
+      repeated Resource volumes = 1;
+    }
+
+    required Type type = 1;
+    optional Launch launch = 2;
+    optional Reserve reserve = 3;
+    optional Unreserve unreserve = 4;
+    optional Create create = 5;
+    optional Destroy destroy = 6;
+  }
 }
 
 
@@ -589,6 +679,19 @@ message TaskInfo {
   // A health check for the task (currently in *alpha* and initial
   // support will only be for TaskInfo's that have a CommandInfo).
   optional HealthCheck health_check = 8;
+
+  // Labels are free-form key value pairs which are exposed through
+  // master and slave endpoints. Labels will not be interpreted or
+  // acted upon by Mesos itself. As opposed to the data field, labels
+  // will be kept in memory on master and slave processes. Therefore,
+  // labels should be used to tag tasks with light-weight meta-data.
+  optional Labels labels = 10;
+
+  // Service discovery information for the task. It is not interpreted
+  // or acted upon by Mesos. It is up to a service discovery system
+  // to use this information as needed and to handle tasks without
+  // service discovery information.
+  optional DiscoveryInfo discovery = 11;
 }
 
 
@@ -600,15 +703,14 @@ message TaskInfo {
  * another task).
  */
 enum TaskState {
-  TASK_STAGING = 6;  // Initial state. Framework status updates should not use.
+  TASK_STAGING = 6; // Initial state. Framework status updates should not use.
   TASK_STARTING = 0;
   TASK_RUNNING = 1;
-  TASK_FINISHED = 2; // TERMINAL.
-  TASK_FAILED = 3;   // TERMINAL.
-  TASK_KILLED = 4;   // TERMINAL.
-  TASK_LOST = 5;     // TERMINAL.
-
-  // TODO(benh): TASK_ERROR = 7; // TERMINAL.
+  TASK_FINISHED = 2; // TERMINAL. The task finished successfully.
+  TASK_FAILED = 3; // TERMINAL. The task failed to finish successfully.
+  TASK_KILLED = 4; // TERMINAL. The task was killed by the executor.
+  TASK_LOST = 5; // TERMINAL. The task failed but can be rescheduled.
+  TASK_ERROR = 7; // TERMINAL. The task description contains an error.
 }
 
 
@@ -616,13 +718,53 @@ enum TaskState {
  * Describes the current status of a task.
  */
 message TaskStatus {
+  /** Describes the source of the task status update. */
+  enum Source {
+    SOURCE_MASTER = 0;
+    SOURCE_SLAVE = 1;
+    SOURCE_EXECUTOR = 2;
+  }
+
+  /** Detailed reason for the task status update. */
+  enum Reason {
+    REASON_COMMAND_EXECUTOR_FAILED = 0;
+    REASON_EXECUTOR_TERMINATED = 1;
+    REASON_EXECUTOR_UNREGISTERED = 2;
+    REASON_FRAMEWORK_REMOVED = 3;
+    REASON_GC_ERROR = 4;
+    REASON_INVALID_FRAMEWORKID = 5;
+    REASON_INVALID_OFFERS = 6;
+    REASON_MASTER_DISCONNECTED = 7;
+    REASON_MEMORY_LIMIT = 8;
+    REASON_RECONCILIATION = 9;
+    REASON_SLAVE_DISCONNECTED = 10;
+    REASON_SLAVE_REMOVED = 11;
+    REASON_SLAVE_RESTARTED = 12;
+    REASON_SLAVE_UNKNOWN = 13;
+    REASON_TASK_INVALID = 14;
+    REASON_TASK_UNAUTHORIZED = 15;
+    REASON_TASK_UNKNOWN = 16;
+  }
+
   required TaskID task_id = 1;
   required TaskState state = 2;
   optional string message = 4; // Possible message explaining state.
+  optional Source source = 9;
+  optional Reason reason = 10;
   optional bytes data = 3;
   optional SlaveID slave_id = 5;
   optional ExecutorID executor_id = 7; // TODO(benh): Use in master/slave.
   optional double timestamp = 6;
+
+  // Statuses that are delivered reliably to the scheduler will
+  // include a 'uuid'. The status is considered delivered once
+  // it is acknowledged by the scheduler. Schedulers can choose
+  // to either explicitly acknowledge statuses or let the scheduler
+  // driver implicitly acknowledge (default).
+  //
+  // TODO(bmahler): This is currently overwritten in the scheduler
+  // driver, even if executors set this.
+  optional bytes uuid = 11;
 
   // Describes whether the task has been determined to be healthy
   // (true) or unhealthy (false) according to the HealthCheck field in
@@ -830,7 +972,8 @@ message Volume {
   // Absolute path pointing to a directory or file in the container.
   required string container_path = 1;
 
-  // Absolute path pointing to a directory or file on the host.
+  // Absolute path pointing to a directory or file on the host or a path
+  // relative to the container work directory.
   optional string host_path = 2;
 
   enum Mode {
@@ -844,21 +987,119 @@ message Volume {
 
 /**
  * Describes a container configuration and allows extensible
- * configurations for different container implementation.
+ * configurations for different container implementations.
  */
 message ContainerInfo {
   // All container implementation types.
   enum Type {
     DOCKER = 1;
+    MESOS = 2;
   }
 
   message DockerInfo {
     // The docker image that is going to be passed to the registry.
     required string image = 1;
+
+    // Network options.
+    enum Network {
+      HOST = 1;
+      BRIDGE = 2;
+      NONE = 3;
+    }
+
+    optional Network network = 2 [default = HOST];
+
+    message PortMapping {
+      required uint32 host_port = 1;
+      required uint32 container_port = 2;
+      // Protocol to expose as (ie: tcp, udp).
+      optional string protocol = 3;
+    }
+
+    repeated PortMapping port_mappings = 3;
+
+    optional bool privileged = 4 [default = false];
+
+    // Allowing arbitrary parameters to be passed to docker CLI.
+    // Note that anything passed to this field is not guaranteed
+    // to be supported moving forward, as we might move away from
+    // the docker CLI.
+    repeated Parameter parameters = 5;
+
+    // With this flag set to true, the docker containerizer will
+    // pull the docker image from the registry even if the image
+    // is already downloaded on the slave.
+    optional bool force_pull_image = 6;
   }
 
   required Type type = 1;
   repeated Volume volumes = 2;
+  optional string hostname = 4;
 
   optional DockerInfo docker = 3;
+}
+
+
+/**
+ * Collection of labels.
+ */
+message Labels {
+    repeated Label labels = 1;
+}
+
+
+/**
+ * Key, value pair used to store free form user-data.
+ */
+message Label {
+  required string key = 1;
+  optional string value = 2;
+}
+
+
+/**
+ * Named port used for service discovery.
+ */
+message Port {
+  required uint32 number = 1;
+  optional string name = 2;
+  optional string protocol = 3;
+}
+
+
+/**
+ * Collection of ports.
+ */
+message Ports {
+  repeated Port ports = 1;
+}
+
+
+/**
+* Service discovery information.
+* The visibility field restricts discovery within a framework
+* (FRAMEWORK), within a Mesos cluster (CLUSTER), or  places no
+* restrictions (EXTERNAL).
+* The environment, location, and version fields provide first class
+* support for common attributes used to differentiate between
+* similar services. The environment may receive values such as
+* PROD/QA/DEV, the location field may receive values like
+* EAST-US/WEST-US/EUROPE/AMEA, and the version field may receive
+* values like v2.0/v0.9. The exact use of these fields is up to each
+* service discovery system.
+*/
+message DiscoveryInfo {
+  enum Visibility {
+    FRAMEWORK = 0;
+    CLUSTER = 1;
+    EXTERNAL = 2;
+  }
+
+  required Visibility visibility = 1;
+  optional string name = 2;
+  optional string environment = 3;
+  optional string location = 4;
+  optional string version = 5;
+  optional Ports ports = 6;
+  optional Labels labels = 7;
 }


### PR DESCRIPTION
This PR upgrades Mesos protocol up to 0.22.1 version (latest stable), the version includes optional `Labels` & `DiscoveryInfo` fields for `TaskInfo`, it could be useful for some goals. Are there any circumstances /needs to keep `pymesos` for older Mesos versions? If there are such, just close this PR.
In my mind it would be better if it could be configured with some setting or in similar way.