### PR TITLE
fix the `RuntimeError: cannot join current thread` when call driver.s…

### DIFF
--- a/pymesos/process.py
+++ b/pymesos/process.py
@@ -147,9 +147,9 @@ class Process(UPID):
 
     def stop(self):
         Process.abort(self)
-        if threading.current_thread() != self.accept_t:
-            logger.debug("join ioloop thread.")
-            self.accept_t.join()
+        assert (threading.current_thread() != self.accept_t), "Can't call stop in accept_t thread."
+        logger.debug("join ioloop thread.")
+        self.accept_t.join()
         if threading.current_thread() != self.delay_t:
             logger.debug("join runjob thread..")
             self.delay_t.join()

--- a/pymesos/process.py
+++ b/pymesos/process.py
@@ -73,6 +73,10 @@ class Process(UPID):
                 if tried < 4:
                     self.jobs.put((t + 3 ** tried, tried + 1, func, args, kw))
 
+        for addr in self.conn_pool:
+            self.conn_pool[addr].close()
+        self.conn_pool.clear()
+
     @async
     def link(self, upid, callback):
         self._get_conn(upid.addr)
@@ -143,14 +147,16 @@ class Process(UPID):
 
     def stop(self):
         Process.abort(self)
-        self.join()
-        for addr in self.conn_pool:
-            self.conn_pool[addr].close()
-        self.conn_pool.clear()
+        if threading.current_thread() != self.accept_t:
+            logger.debug("join ioloop thread.")
+            self.accept_t.join()
+        if threading.current_thread() != self.delay_t:
+            logger.debug("join runjob thread..")
+            self.delay_t.join()
 
     def join(self):
-        self.delay_t.join()
-        return self.accept_t.join()
+        self.accept_t.join()
+        return self.delay_t.join()
 
     def run(self):
         self.start()


### PR DESCRIPTION
According to the official documents, calling `driver.stop()` in scheduler's  api is allowed, but when I use pymesos, it'll throw an RuntimeError as issue #8 described. this PR fixes this problem. 