### PR TITLE
allow to run `driver.stop` in delay_t thread

### DIFF
--- a/pymesos/process.py
+++ b/pymesos/process.py
@@ -73,6 +73,10 @@ class Process(UPID):
                 if tried < 4:
                     self.jobs.put((t + 3 ** tried, tried + 1, func, args, kw))
 
+        for addr in self.conn_pool:
+            self.conn_pool[addr].close()
+        self.conn_pool.clear()
+
     @async
     def link(self, upid, callback):
         self._get_conn(upid.addr)
@@ -144,13 +148,10 @@ class Process(UPID):
     def stop(self):
         Process.abort(self)
         self.join()
-        for addr in self.conn_pool:
-            self.conn_pool[addr].close()
-        self.conn_pool.clear()
 
     def join(self):
-        self.delay_t.join()
-        return self.accept_t.join()
+        self.accept_t.join()
+        return self.delay_t.join()
 
     def run(self):
         self.start()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version=version,
     description="A pure python implementation of Mesos scheduler and executor",
     packages=find_packages(),
-    install_requires=['mesos.interface==0.22.0'],
+    install_requires=['mesos.interface>=0.22.0,<0.22.1.2'],
     platforms=['POSIX'],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
I've several reasons why pymesos needs this PR:

1. this PR don't break down the existing code, every mesos framework works well with the current version of pymesos will also works well with new version. because `driver.stop` is called either in main thread or a new thread in existing code.
2. with current version of pymesos, I must start a new thread to check the success condition periodically, I think this way is ugly, because in most case, statusUpdate is the good place to check the finished condition and also a good place to stop the scheduler， I know `abort` can do this job, but I really don't like the word `abort`, because I just want to stop the scheduler not abort. maybe we need to remove thread join code in `stop`, but this will break down the existing code which don't call join, so it's not a good solution.
3. pymesos is announced as pure python implementation of mesos'native binding, so I think pymesos should at least works well with the official example code 

finally if you really don't think this is a good solution, then it's better to point out this incompatibility in readme。 thx