### PR TITLE
Fix new-master msg handler (MESOS-3135)

### DIFF
--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -38,6 +38,7 @@ class MesosSchedulerDriver(Process):
 
     @async # called by detector
     def onNewMasterDetectedMessage(self, data):
+        master = None
         try:
             parsed = json.loads(data)
             if parsed and "address" in parsed:

--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -1,3 +1,4 @@
+import json
 import time
 import logging
 import struct
@@ -38,12 +39,23 @@ class MesosSchedulerDriver(Process):
     @async # called by detector
     def onNewMasterDetectedMessage(self, data):
         try:
-            info = MasterInfo()
-            info.ParseFromString(data)
-            ip = socket.inet_ntoa(struct.pack('<I', info.ip))
-            master = UPID('master@%s:%s' % (ip, info.port))
-        except:
-            master = UPID(data)
+            parsed = json.loads(data)
+            if parsed and "address" in parsed:
+                ip = parsed["address"].get("ip")
+                port = parsed["address"].get("port")
+                if ip and port:
+                    master = UPID("master@%s:%s" % (ip, port))
+        except ValueError as parse_error:
+            logger.debug("No JSON content, probably connecting "
+                         "to older Mesos version. Reason: %s", parse_error)
+        if not master:
+            try:
+                info = MasterInfo()
+                info.ParseFromString(data)
+                ip = socket.inet_ntoa(struct.pack('<I', info.ip))
+                master = UPID('master@%s:%s' % (ip, info.port))
+            except:
+                master = UPID(data)
 
         self.connected = False
         self.register(master)


### PR DESCRIPTION
The current pymesos version (`#a6a64bac50bf`) doesn't work well for Mesos >=0.24 due to https://issues.apache.org/jira/browse/MESOS-3135 (ZK Mesos master data serialization with JSON instead of protocol buff). 

The PR implements a necessary fix to parse ZK data properly for last Mesos versions.

Review, please, and let me know what do you think about it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/douban/pymesos/15)
<!-- Reviewable:end -->
