### PR TITLE
ListFields() does not return unset fields

### DIFF
--- a/pymesos/process.py
+++ b/pymesos/process.py
@@ -138,8 +138,8 @@ class Process(UPID):
         name = msg.__class__.__name__
         f = getattr(self, 'on' + name, None)
         assert f, 'should have on%s()' % name
-        args = [v for (_,v) in msg.ListFields()]
-        f(*args)
+        args = {f.name: getattr(msg, f.name) for f in msg.DESCRIPTOR.fields}
+        f(**args)
 
     def abort(self):
         self.aborted = True

--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -104,7 +104,7 @@ class MesosSchedulerDriver(Process):
         logger.warning("disconnected from master")
         self.delay(5, lambda:self.register(self.master))
 
-    def onResourceOffersMessage(self, offers, pids):
+    def onResourceOffersMessage(self, offers, pids, inverse_offers=None):
         for offer, pid in zip(offers, pids):
             self.savedOffers.setdefault(offer.id.value, {})[offer.slave_id.value] = UPID(pid)
         self.sched.resourceOffers(self, list(offers))


### PR DESCRIPTION
ResourceOffersMessage that includes [InverseOffers](http://mesos.apache.org/documentation/latest/maintenance/) does not include Offers so `Resource.OffersMessage.ListFields()` returns `(pids, inverse_offers)` instead of `(offers, pids, inverse_offers)` 

This change ensures all fields in message are mapped to handle function arguments.