### PR TITLE
Run tests against py34 and py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
             - libzookeeper-mt-dev
 env:
     - TOX_ENV=py27
+    - TOX_ENV=py34
     - TOX_ENV=py35
+    - TOX_ENV=py36
     - TOX_ENV=pypy
     - TOX_ENV=flake8
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, pypy, flake8
+envlist = py27, py34, py35, py36, pypy, flake8
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
I'm using pymesos in conjunction with a custom Mesos executor for Airflow.  This PR just adds support for py34 and py36 to pymesos in tox and Travis (which the unit tests already pass on).