### PR TITLE
Fix inverse offers

### DIFF
--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -444,6 +444,9 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
                 self, [self._dict_cls(offer) for offer in inverse_offers]
             )
 
+    def on_inverse_offers(self, event):
+        self.on_offers(event)
+
     def on_rescind(self, event):
         offer_id = event['offer_id']
         self.sched.offerRescinded(self, self._dict_cls(offer_id))


### PR DESCRIPTION
Inverse offers are received with an 'inverse_offers' event type, for
which there was no handler (at least in Mesos 1.4.0 - I don't know if
the existing code worked for other versions of Mesos). I've added an
on_inverse_offers wrapper that just forwards to on_offers.