### PR TITLE
Fix construction of AcceptInverseOffers/DeclineInverseOffers

### DIFF
--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -218,7 +218,7 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
         assert framework_id
 
         accept_inverse_offers = dict(
-            offer_ids=[offer_ids] if isinstance(offer_ids, dict) else offer_ids
+            inverse_offer_ids=[offer_ids] if isinstance(offer_ids, dict) else offer_ids
         )
 
         if filters is not None:
@@ -272,7 +272,7 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
         framework_id = self.framework_id
         assert framework_id
         decline_inverse_offers = dict(
-            offer_ids=[offer_ids] if isinstance(offer_ids, dict) else offer_ids
+            inverse_offer_ids=[offer_ids] if isinstance(offer_ids, dict) else offer_ids
         )
 
         if filters is not None:


### PR DESCRIPTION
They were passing a field called offer_ids, whereas the protocol
expected inverse_offer_ids (see
https://github.com/apache/mesos/blob/master/include/mesos/scheduler/scheduler.proto).