### PR TITLE
Update Operator API with latest changes and add missing lock object in MesosOperatorAgentDriver which is needed in _send method from super class

### DIFF
--- a/pymesos/interface.py
+++ b/pymesos/interface.py
@@ -737,10 +737,13 @@ class OperatorAgentDriver(OperatorDaemonDriver):
     This API contains all the calls accepted by the agent.
   """
 
-  def getContainers(self):
+  def getContainers(self, show_nested=False, show_standalone=False):
     """
       This call retrieves information about containers running on this agent. It contains ContainerStatus and
       ResourceStatistics along with some metadata of the containers.
+      There are two knobs in the request to control the types of the containers this API will return:
+      * show_nested: Whether to show nested containers [default: false].
+      * show_standalone: Whether to show standalone containers [default: false].
     """
 
   def launchNestedContainer(self, launch_nested_container):

--- a/pymesos/operator_v1.py
+++ b/pymesos/operator_v1.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from threading import RLock
 
 from addict import Dict
 from six.moves.http_client import HTTPConnection
@@ -412,10 +413,15 @@ class MesosOperatorMasterDriver(Process, MesosOperatorDaemonDriver):
 class MesosOperatorAgentDriver(MesosOperatorDaemonDriver):
     def __init__(self, agent_uri):
         super(MesosOperatorAgentDriver, self).__init__(agent_uri)
+        self._lock = RLock()
 
-    def getContainers(self):
+    def getContainers(self, show_nested=False, show_standalone=False):
         body = dict(
             type='GET_CONTAINERS',
+            get_containers=dict(
+                show_nested=show_nested,
+                show_standalone=show_standalone,
+            ),
         )
         return self._send(body)
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -858,8 +858,8 @@ def test_get_containers(mocker):
     driver._send.assert_called_once_with({
         'type': 'GET_CONTAINERS',
         'get_containers': {
-            'show_nested': 'true',
-            'show_standalone': 'false',
+            'show_nested': True,
+            'show_standalone': False,
         }
     })
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -854,9 +854,13 @@ def test_get_containers(mocker):
     agent = mocker.Mock()
     driver = MesosOperatorAgentDriver(agent)
     driver._send = mocker.Mock()
-    driver.getContainers()
+    driver.getContainers(show_nested=True)
     driver._send.assert_called_once_with({
         'type': 'GET_CONTAINERS',
+        'get_containers': {
+            'show_nested': 'true',
+            'show_standalone': 'false',
+        }
     })
 
 


### PR DESCRIPTION
Update Operator API with latest changes
Add missing lock object in MesosOperatorAgentDriver which is needed in _send method from super class