### PR TITLE
Drop python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     include:
         - python: 2.7
           env: TOX_ENV=py27
-        - python: 3.3
-          env: TOX_ENV=py33
         - python: 3.4
           env: TOX_ENV=py34
         - python: 3.5


### PR DESCRIPTION
[Python 3.3](https://en.wikipedia.org/wiki/CPython#Version_history) reached the end of its life on 29 September 2017, travis-ci also drop python 3.3 support, so just drop it.