### PR TITLE
Add ability to pass roles to reviveOffers and suppressOffers

### DIFF
--- a/pymesos/scheduler.py
+++ b/pymesos/scheduler.py
@@ -305,7 +305,7 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
         )
         self._send(body)
 
-    def reviveOffers(self):
+    def reviveOffers(self, roles=()):
         if not self.connected:
             return
 
@@ -317,9 +317,11 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
                 value=framework_id,
             ),
         )
+        if roles:
+            body['revive'] = dict(roles=list(roles))
         self._send(body)
 
-    def suppressOffers(self):
+    def suppressOffers(self, roles=()):
         if not self.connected:
             return
 
@@ -331,6 +333,8 @@ class MesosSchedulerDriver(Process, SchedulerDriver):
                 value=framework_id,
             ),
         )
+        if roles:
+            body['suppress'] = dict(roles=list(roles))
         self._send(body)
 
     def killTask(self, task_id):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -223,6 +223,63 @@ def test_revive_offers(mocker):
     })
 
 
+def test_revive_offers_roles(mocker):
+    ID = str(uuid.uuid4())
+    sched = mocker.Mock()
+    framework = {'id': {'value': ID}}
+    master = mocker.Mock()
+    driver = MesosSchedulerDriver(sched, framework, master)
+    driver._send = mocker.Mock()
+    driver._stream_id = str(uuid.uuid4())
+    driver.reviveOffers(['role1', 'role2'])
+    driver._send.assert_called_once_with({
+        'type': 'REVIVE',
+        'framework_id': {
+            'value': ID
+        },
+        'revive': {
+            'roles': ['role1', 'role2']
+        }
+    })
+
+
+def test_suppress_offers(mocker):
+    ID = str(uuid.uuid4())
+    sched = mocker.Mock()
+    framework = {'id': {'value': ID}}
+    master = mocker.Mock()
+    driver = MesosSchedulerDriver(sched, framework, master)
+    driver._send = mocker.Mock()
+    driver._stream_id = str(uuid.uuid4())
+    driver.suppressOffers()
+    driver._send.assert_called_once_with({
+        'type': 'SUPPRESS',
+        'framework_id': {
+            'value': ID
+        },
+    })
+
+
+def test_suppress_offers_roles(mocker):
+    ID = str(uuid.uuid4())
+    sched = mocker.Mock()
+    framework = {'id': {'value': ID}}
+    master = mocker.Mock()
+    driver = MesosSchedulerDriver(sched, framework, master)
+    driver._send = mocker.Mock()
+    driver._stream_id = str(uuid.uuid4())
+    driver.suppressOffers(['role1', 'role2'])
+    driver._send.assert_called_once_with({
+        'type': 'SUPPRESS',
+        'framework_id': {
+            'value': ID
+        },
+        'suppress': {
+            'roles': ['role1', 'role2']
+        }
+    })
+
+
 def test_kill_task(mocker):
     ID = str(uuid.uuid4())
     sched = mocker.Mock()


### PR DESCRIPTION
If roles are specified, they are passed in the message. This is a
feature available from Mesos 1.3.

Also added a unit tests for suppressOffers without roles, since there
wasn't one.