### PR TITLE
Follow 307 redirect for Mesos operator

### DIFF
--- a/pymesos/operator_v1.py
+++ b/pymesos/operator_v1.py
@@ -1,10 +1,10 @@
 import json
 import logging
 from threading import RLock
-from urlparse import urlparse
 
 from addict import Dict
 from six.moves.http_client import HTTPConnection
+from six.moves.urllib.parse import urlparse
 
 from .interface import OperatorDaemonDriver
 from .process import Process
@@ -61,7 +61,7 @@ class MesosOperatorDaemonDriver(OperatorDaemonDriver):
                 
             if resp.status >= 300 and resp.status <= 399:
                 url = resp.getheader('location')
-                parsed = urlparse(url, allow_fragments=True)
+                parsed = urlparse(url)
                 self._daemon = '%s:%s' % (parsed.hostname, parsed.port)
                 self._conn.close()
                 self._conn = None

--- a/pymesos/operator_v1.py
+++ b/pymesos/operator_v1.py
@@ -59,7 +59,7 @@ class MesosOperatorDaemonDriver(OperatorDaemonDriver):
                 self._conn = None
                 raise
                 
-            if resp.status <= 300 and resp.status <= 399:
+            if resp.status >= 300 and resp.status <= 399:
                 url = resp.getheader('location')
                 parsed = urlparse(url, allow_fragments=True)
                 self._daemon = '%s:%s' % (parsed.hostname, parsed.port)

--- a/pymesos/operator_v1.py
+++ b/pymesos/operator_v1.py
@@ -58,7 +58,7 @@ class MesosOperatorDaemonDriver(OperatorDaemonDriver):
                 self._conn.close()
                 self._conn = None
                 raise
-                
+
             if resp.status >= 300 and resp.status <= 399:
                 url = resp.getheader('location')
                 parsed = urlparse(url)


### PR DESCRIPTION
I was getting errors like this when a new Mesos master was elected as leader and the old Mesos master was return 307 status codes, as described [here](https://mesos.apache.org/documentation/latest/scheduler-http-api/#master-detection):

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-5-97ca5d57dd56> in <module>()
----> 1 mesos_manager.master_operator.getAgents()

/usr/local/lib/python2.7/dist-packages/pymesos/operator_v1.pyc in getAgents(self)
    261             type='GET_AGENTS',
    262         )
--> 263         return self._send(body)
    264
    265     def getRoles(self):

/usr/local/lib/python2.7/dist-packages/pymesos/operator_v1.pyc in _send(self, body, path, method, headers)
     62                 raise RuntimeError(
     63                     'Failed to send request code=%s, message=%s' % (
---> 64                         resp.status, resp.read()
     65                     )
     66                 )

RuntimeError: Failed to send request code=307, message=
```

I have added a check for 3xx response codes, and updated the daemon URI accordingly for subsequent requests.

I'm not sure if this is also required for `scheduler.py`, as I found that my scheduler worker was still working fine despite the leader change, not sure why as well.

On the other hand, should I be using MasterDetector to handle this case instead? In any case, I feel like we should be supporting both use cases for Mesos master HA in any case.